### PR TITLE
icon urls have no space and are always lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const log = console.log;
 
 const isValidHex = str => /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(str);
 const isValidString = str => str && str.length > 2;
-const getUrl = name => `https://simpleicons.org/icons/${name}.svg`;
+const getUrl = name => `https://simpleicons.org/icons/${name}.svg`.replace(/\s/g, '').toLowerCase();
 const spinner = ora("Generating your Icon...");
 spinner.color = "yellow";
 


### PR DESCRIPTION
Examples of icons with spaces in title and their corresponding url. Fixes #2 

**Adobe InDesign:** https://simpleicons.org/icons/adobeindesign.svg
**Buy me a coffee:** https://simpleicons.org/icons/buymeacoffee.svg

Example use after fix:

```
$ csi "Adobe Photoshop"
✔ Done! Look for Adobe Photoshop.svg
```